### PR TITLE
remove logger deprecation warning

### DIFF
--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -143,7 +143,7 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
     dropped_bytes = byte_size(state.queue)
 
     if dropped_bytes > 0 do
-      Membrane.Logger.warn(
+      Membrane.Logger.warning(
         "Dropping enqueued #{dropped_bytes} on EoS. It's possible that the stream was ended abrubtly or the provided formats are invalid."
       )
     end


### PR DESCRIPTION
While working on #45  i saw the deprecation warning with Elixir 1.15

```shell
warning: Logger.warn/2 is deprecated. Use Logger.warning/2 instead
  lib/membrane_ffmpeg_swresample_plugin/converter.ex:146: Membrane.FFmpeg.SWResample.Converter.handle_end_of_stream/3
```