### PR TITLE
Don't try to flush if the stream format never came

### DIFF
--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -136,6 +136,10 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   end
 
   @impl true
+  def handle_end_of_stream(:input, _ctx, %{native: nil} = state) do
+    {[end_of_stream: :output], state}
+  end
+
   def handle_end_of_stream(:input, _ctx, state) do
     dropped_bytes = byte_size(state.queue)
 


### PR DESCRIPTION
In my pipeline an element which comes before the converter is sending an EOS before it has forwarded the stream format (the element itself never received the stream format to forward). This is raising an error when the converter tries to process the end of stream, since the `native` is nil. 

In this case, we should probably just forward the eos through the output pad.