### PR TITLE
Handle Stream Format flush fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is a part of [Membrane Multimedia Framework](https://membrane.stream).
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-{:membrane_ffmpeg_swresample_plugin, "~> 0.20.1"}
+{:membrane_ffmpeg_swresample_plugin, "~> 0.20.2"}
 ```
 
 The precompiled builds of the [ffmpeg](https://www.ffmpeg.org) will be pulled and linked automatically. However, should there be any problems, consider installing it manually.

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -117,14 +117,18 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
     check_dropped_frames(state)
 
     flushed_actions =
-      case flush!(state.native) do
-        <<>> ->
-          []
+      if state.native == nil do
+        []
+      else
+        case flush!(state.native) do
+          <<>> ->
+            []
 
-        converted ->
-          output_duration = calculate_output_duration(converted, state)
-          {_state, out_pts} = update_pts_queue(state, output_duration, true)
-          [buffer: {:output, %Buffer{payload: converted, pts: out_pts}}]
+          converted ->
+            output_duration = calculate_output_duration(converted, state)
+            {_state, out_pts} = update_pts_queue(state, output_duration, true)
+            [buffer: {:output, %Buffer{payload: converted, pts: out_pts}}]
+        end
       end
 
     # create new converter

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Membrane.FFmpeg.SWResample.Mixfile do
   use Mix.Project
 
   @github_url "https://github.com/membraneframework/membrane_ffmpeg_swresample_plugin"
-  @version "0.20.1"
+  @version "0.20.2"
 
   def project do
     [


### PR DESCRIPTION
After adding converter flushing in `handle_stream_format` in last update, there is now a case in which if stream format is changed before any converting was done, native converter is nil, causing :unifex_parse_arg and crash of pipeline.
I've observed this while testing some demos in membrane_demo.
This PR fixes the issue.