### PR TITLE
Switch to new AVChannelLayout API

### DIFF
--- a/c_src/membrane_ffmpeg_swresample_plugin/converter_lib.h
+++ b/c_src/membrane_ffmpeg_swresample_plugin/converter_lib.h
@@ -14,8 +14,9 @@ typedef struct ConverterState
 
 char *lib_init(ConverterState *state, char from_s24le,
                enum AVSampleFormat src_sample_fmt, int src_rate,
-               int64_t src_ch_layout, enum AVSampleFormat dst_sample_fmt,
-               int dst_rate, int64_t dst_ch_layout);
+               const AVChannelLayout *src_ch_layout,
+               enum AVSampleFormat dst_sample_fmt, int dst_rate,
+               const AVChannelLayout *dst_ch_layout);
 
 char *lib_convert(ConverterState *state, uint8_t *input, int input_size,
                   uint8_t **output, int *output_size);


### PR DESCRIPTION
A major FFMPEG version bump has removed deprecated features currently in use.
This PR updates to use new AVChannelLayout to avoid errors which look something like:
```
[SWR @ 0x7efc840659c0] Input channel layout "" is invalid or unsupported.
21:41:52.374 [error] <0.1145.0>/:converter Error occured in Membrane Element:
** (RuntimeError) Error while initializing native converter: :swr_init                                                                                   
Input format: %Membrane.RawAudio{channels: 2, sample_rate: 48000, sample_format: :s24le}                                                                 
Output format: %Membrane.RawAudio{channels: 2, sample_rate: 24000, sample_format: :s16le}                                                                
                                                                                                                                                         
    (membrane_ffmpeg_swresample_plugin 0.20.3) lib/membrane_ffmpeg_swresample_plugin/converter.ex:239: Membrane.FFmpeg.SWResample.Converter.mk_native!/2 
    (membrane_ffmpeg_swresample_plugin 0.20.3) lib/membrane_ffmpeg_swresample_plugin/converter.ex:79: Membrane.FFmpeg.SWResample.Converter.handle_setup/2
    (membrane_core 1.2.4) lib/membrane/core/callback_handler.ex:141: anonymous fn/3 in Membrane.Core.CallbackHandler.exec_callback/4                     
    (membrane_core 1.2.4) lib/membrane/core/callback_handler.ex:144: Membrane.Core.CallbackHandler.exec_callback/4                                       
    (membrane_core 1.2.4) lib/membrane/core/callback_handler.ex:70: Membrane.Core.CallbackHandler.exec_and_handle_callback/5                             
    (membrane_core 1.2.4) lib/membrane/core/element/lifecycle_controller.ex:62: Membrane.Core.Element.LifecycleController.handle_setup/1                 
    (membrane_core 1.2.4) lib/membrane/core/element.ex:167: Membrane.Core.Element.handle_continue/2                                                      
    (stdlib 7.1) gen_server.erl:2424: :gen_server.try_handle_continue/3                                                                                  
    (stdlib 7.1) gen_server.erl:2291: :gen_server.loop/4                                                                                                 
    (stdlib 7.1) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
```