### PR TITLE
Fix failing test blocking v0.20.6 release

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+if config_env() == :test do
+  import_config "test.exs"
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :mockery, enable: true

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -5,7 +5,7 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   """
 
   use Membrane.Filter
-  import Mockery.Macro
+  use Mockery.Macro
 
   require Membrane.Logger
 


### PR DESCRIPTION
## Root cause

The `v0.20.6` Release run failed at `test / test (1)` -> "Run tests", so `hex_publish` was skipped.

CI runs `mix test --warnings-as-errors`. This is dependency drift, not a product bug: `mix.exs` pins `{:mockery, "~> 2.1"}`, which now resolves to **2.5.0**. Mockery 2.4.0 deprecated `Mockery.Macro.mockable/2` based on `Mix.env/0`, and 2.5.0 no longer injects `@compile {:no_warn_undefined, Mockery.Proxy.MacroProxy}` unless Mockery is explicitly enabled. As a result the converter emitted compile warnings under `--warnings-as-errors`:

- `Mockery.Macro.mockable/2 based on Mix.env/0 is deprecated ...`
- `Mockery.Proxy.MacroProxy.create/6 is undefined or private`
- `Mockery.Proxy.MacroProxy.convert/2 is undefined or private`

## Fix

Following Mockery's own migration guidance (no deps pinned/downgraded):

- Add `config/config.exs` + `config/test.exs` with `config :mockery, enable: true` (removes the `Mix.env/0` deprecation).
- Switch the converter from `import Mockery.Macro` to `use Mockery.Macro`, the documented usage, which injects `@compile {:no_warn_undefined, Mockery.Proxy.MacroProxy}` and silences the undefined-proxy warnings.

## Verification

- `mix compile --force --warnings-as-errors` (dev and test): pass
- `mix test --warnings-as-errors`: 20 tests, 0 failures
- `mix format --check-formatted`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
