### PR TITLE
Add option to preserve input stream parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is a part of [Membrane Multimedia Framework](https://membrane.stream).
 Add the following line to your `deps` in `mix.exs`. Run `mix deps.get`.
 
 ```elixir
-{:membrane_ffmpeg_swresample_plugin, "~> 0.20.6"}
+{:membrane_ffmpeg_swresample_plugin, "~> 0.21.0"}
 ```
 
 The precompiled builds of the [ffmpeg](https://www.ffmpeg.org) will be pulled and linked automatically. However, should there be any problems, consider installing it manually.
@@ -56,7 +56,7 @@ defmodule Resampling.Pipeline do
       child(:file_src, %File.Source{location: "/tmp/input.raw"})
       |> child(:converter, %Converter{
         input_stream_format: %RawAudio{channels: 2, sample_format: :s24le, sample_rate: 48_000},
-        output_stream_format: %RawAudio{channels: 2, sample_format: :f32le, sample_rate: 44_100}
+        output_stream_format: %Converter.OutputFormat{channels: 2, sample_format: :f32le, sample_rate: 44_100}
       })
       |> child(:file_sink, %File.Sink{location: "/tmp/output.raw"})
     ]

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -211,23 +211,13 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   end
 
   defp resolve_output_stream_format(input_format, output_format) do
-    %RawAudio{
-      sample_format:
-        if(output_format.sample_format == :keep,
-          do: input_format.sample_format,
-          else: output_format.sample_format
-        ),
-      sample_rate:
-        if(output_format.sample_rate == :keep,
-          do: input_format.sample_rate,
-          else: output_format.sample_rate
-        ),
-      channels:
-        if(output_format.channels == :keep,
-          do: input_format.channels,
-          else: output_format.channels
-        )
-    }
+    overrides =
+      output_format |> Map.from_struct() |> Map.reject(fn {_key, val} -> val == :keep end)
+
+    merged =
+      input_format |> Map.from_struct() |> Map.merge(overrides)
+
+    struct!(RawAudio, merged)
   end
 
   defp check_dropped_frames(state) do

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -12,14 +12,23 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   alias __MODULE__.Native
   alias Membrane.{Buffer, RawAudio, RemoteStream}
 
+  defmodule OutputFormat do
+    @moduledoc """
+    Struct defining the output stream format of the converter. If a field 
+    is set to `:keep`, then its value will be preserved from input stream format.
+    """
+
+    @typedoc @moduledoc
+    @type t :: %__MODULE__{
+            sample_format: RawAudio.SampleFormat.t() | :keep,
+            sample_rate: RawAudio.sample_rate_t() | :keep,
+            channels: RawAudio.channels_t() | :keep
+          }
+    defstruct sample_format: :keep, sample_rate: :keep, channels: :keep
+  end
+
   @supported_sample_format [:u8, :s16le, :s24le, :s32le, :f32le, :f64le]
   @supported_channels [1, 2]
-
-  @type output_stream_format :: %{
-          optional(:sample_format) => RawAudio.SampleFormat.t() | :keep,
-          optional(:sample_rate) => RawAudio.sample_rate_t() | :keep,
-          optional(:channels) => RawAudio.channels_t() | :keep
-        }
 
   def_output_pad :output,
     accepted_format:
@@ -44,10 +53,10 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
                 """
               ],
               output_stream_format: [
-                spec: output_stream_format(),
+                spec: OutputFormat.t(),
                 description: """
-                Defines how the output stream format will be determined. If a field is not set or
-                set to `:keep`, then its value will be preserved from input stream format.
+                Defines how the output stream format will be determined. If a field is set
+                to `:keep`, then its value will be preserved from input stream format.
                 """
               ]
 
@@ -204,17 +213,17 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   defp resolve_output_stream_format(input_format, output_format) do
     %RawAudio{
       sample_format:
-        if(Map.get(output_format, :sample_format, :keep) == :keep,
+        if(output_format.sample_format == :keep,
           do: input_format.sample_format,
           else: output_format.sample_format
         ),
       sample_rate:
-        if(Map.get(output_format, :sample_rate, :keep) == :keep,
+        if(output_format.sample_rate == :keep,
           do: input_format.sample_rate,
           else: output_format.sample_rate
         ),
       channels:
-        if(Map.get(output_format, :channels, :keep) == :keep,
+        if(output_format.channels == :keep,
           do: input_format.channels,
           else: output_format.channels
         )

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -16,9 +16,9 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   @supported_channels [1, 2]
 
   @type output_stream_format :: %{
-          sample_format: RawAudio.SampleFormat.t() | :keep,
-          sample_rate: RawAudio.sample_rate_t() | :keep,
-          channels: RawAudio.channels_t() | :keep
+          optional(:sample_format) => RawAudio.SampleFormat.t() | :keep,
+          optional(:sample_rate) => RawAudio.sample_rate_t() | :keep,
+          optional(:channels) => RawAudio.channels_t() | :keep
         }
 
   def_output_pad :output,
@@ -46,8 +46,8 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
               output_stream_format: [
                 spec: output_stream_format(),
                 description: """
-                Defines how the output stream format will be determined. If a field is set to
-                `:keep`, then it's value will be preserved from input stream format.
+                Defines how the output stream format will be determined. If a field is not set or
+                set to `:keep`, then its value will be preserved from input stream format.
                 """
               ]
 
@@ -57,14 +57,6 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
       %RawAudio{} -> :ok
       nil -> :ok
       _other -> raise ":input_stream_format must be nil or %RawAudio{}"
-    end
-
-    case options.output_stream_format do
-      %{sample_format: _format, sample_rate: _rate, channels: _channels} ->
-        :ok
-
-      _other ->
-        raise ":output_stream_format must be a map with :sample_format, :sample_rate and :channels"
     end
 
     state =
@@ -212,17 +204,17 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   defp resolve_output_stream_format(input_format, output_format) do
     %RawAudio{
       sample_format:
-        if(output_format.sample_format == :keep,
+        if(Map.get(output_format, :sample_format, :keep) == :keep,
           do: input_format.sample_format,
           else: output_format.sample_format
         ),
       sample_rate:
-        if(output_format.sample_rate == :keep,
+        if(Map.get(output_format, :sample_rate, :keep) == :keep,
           do: input_format.sample_rate,
           else: output_format.sample_rate
         ),
       channels:
-        if(output_format.channels == :keep,
+        if(Map.get(output_format, :channels, :keep) == :keep,
           do: input_format.channels,
           else: output_format.channels
         )

--- a/lib/membrane_ffmpeg_swresample_plugin/converter.ex
+++ b/lib/membrane_ffmpeg_swresample_plugin/converter.ex
@@ -12,8 +12,14 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   alias __MODULE__.Native
   alias Membrane.{Buffer, RawAudio, RemoteStream}
 
-  @supported_sample_format [:u8, :s16le, :s32le, :f32le, :f64le]
+  @supported_sample_format [:u8, :s16le, :s24le, :s32le, :f32le, :f64le]
   @supported_channels [1, 2]
+
+  @type output_stream_format :: %{
+          sample_format: RawAudio.SampleFormat.t() | :keep,
+          sample_rate: RawAudio.sample_rate_t() | :keep,
+          channels: RawAudio.channels_t() | :keep
+        }
 
   def_output_pad :output,
     accepted_format:
@@ -25,8 +31,7 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
       any_of(
         %RawAudio{sample_format: format, channels: channels}
         when format in @supported_sample_format and channels in @supported_channels,
-        %RemoteStream{content_format: format} when format in [nil, RawAudio],
-        %RawAudio{sample_format: :s24le, channels: channels} when channels in @supported_channels
+        %RemoteStream{content_format: format} when format in [nil, RawAudio]
       )
 
   def_options input_stream_format: [
@@ -39,9 +44,10 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
                 """
               ],
               output_stream_format: [
-                spec: RawAudio.t(),
+                spec: output_stream_format(),
                 description: """
-                Audio stream format for output pad
+                Defines how the output stream format will be determined. If a field is set to
+                `:keep`, then it's value will be preserved from input stream format.
                 """
               ]
 
@@ -54,30 +60,26 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
     end
 
     case options.output_stream_format do
-      %RawAudio{} -> :ok
-      _other -> raise ":output_stream_format must be %RawAudio{}"
+      %{sample_format: _format, sample_rate: _rate, channels: _channels} ->
+        :ok
+
+      _other ->
+        raise ":output_stream_format must be a map with :sample_format, :sample_rate and :channels"
     end
 
     state =
-      options
-      |> Map.from_struct()
-      |> Map.merge(%{
+      %{
         native: nil,
         queue: <<>>,
+        input_stream_format: options.input_stream_format,
         input_stream_format_provided?: options.input_stream_format != nil,
+        options_output_stream_format: options.output_stream_format,
+        resolved_output_stream_format: nil,
         pts_queue: [],
         last_valid_pts: nil
-      })
+      }
 
     {[], state}
-  end
-
-  @impl true
-  def handle_setup(_ctx, %{input_stream_format_provided?: false} = state), do: {[], state}
-
-  def handle_setup(_ctx, state) do
-    native = mk_native!(state.input_stream_format, state.output_stream_format)
-    {[], %{state | native: native}}
   end
 
   @impl true
@@ -94,9 +96,17 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
         _ctx,
         %{input_stream_format: stored_stream_format} = state
       ) do
-    native = mk_native!(stored_stream_format, state.output_stream_format)
-    state = %{state | native: native}
-    {[stream_format: {:output, state.output_stream_format}], state}
+    resolved_output_stream_format =
+      resolve_output_stream_format(stored_stream_format, state.options_output_stream_format)
+
+    native = mk_native!(stored_stream_format, resolved_output_stream_format)
+
+    {[stream_format: {:output, resolved_output_stream_format}],
+     %{
+       state
+       | native: native,
+         resolved_output_stream_format: resolved_output_stream_format
+     }}
   end
 
   @impl true
@@ -132,23 +142,22 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
       end
 
     # create new converter
-    native = mk_native!(stream_format, state.output_stream_format)
+    resolved_output_stream_format =
+      resolve_output_stream_format(stream_format, state.options_output_stream_format)
+
+    native = mk_native!(stream_format, resolved_output_stream_format)
 
     state = %{
       state
       | native: native,
         input_stream_format: stream_format,
+        resolved_output_stream_format: resolved_output_stream_format,
         queue: <<>>,
         pts_queue: [],
         last_valid_pts: nil
     }
 
-    {flushed_actions ++ [stream_format: {:output, state.output_stream_format}], state}
-  end
-
-  @impl true
-  def handle_playing(_ctx, state) do
-    {[stream_format: {:output, state.output_stream_format}], state}
+    {flushed_actions ++ [stream_format: {:output, resolved_output_stream_format}], state}
   end
 
   @impl true
@@ -157,7 +166,8 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
 
     state =
       Map.update!(state, :pts_queue, fn pts_queue ->
-        pts_queue ++ [{input_pts, byte_size(payload) * state.output_stream_format.sample_rate}]
+        pts_queue ++
+          [{input_pts, byte_size(payload) * state.resolved_output_stream_format.sample_rate}]
       end)
 
     conversion_result =
@@ -199,6 +209,26 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
     end
   end
 
+  defp resolve_output_stream_format(input_format, output_format) do
+    %RawAudio{
+      sample_format:
+        if(output_format.sample_format == :keep,
+          do: input_format.sample_format,
+          else: output_format.sample_format
+        ),
+      sample_rate:
+        if(output_format.sample_rate == :keep,
+          do: input_format.sample_rate,
+          else: output_format.sample_rate
+        ),
+      channels:
+        if(output_format.channels == :keep,
+          do: input_format.channels,
+          else: output_format.channels
+        )
+    }
+  end
+
   defp check_dropped_frames(state) do
     dropped_bytes = byte_size(state.queue)
 
@@ -214,9 +244,9 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   defp mk_native!(
          %RawAudio{
            sample_format: in_sample_format,
-           sample_rate: input_rate,
-           channels: input_channels
-         } = input_format,
+           sample_rate: in_rate,
+           channels: in_channels
+         } = in_format,
          %RawAudio{
            sample_format: out_sample_format,
            sample_rate: out_rate,
@@ -225,8 +255,8 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
        ) do
     mockable(Native).create(
       in_sample_format |> RawAudio.SampleFormat.serialize(),
-      input_rate,
-      input_channels,
+      in_rate,
+      in_channels,
       out_sample_format |> RawAudio.SampleFormat.serialize(),
       out_rate,
       out_channels
@@ -238,7 +268,7 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
       {:error, reason} ->
         raise """
         Error while initializing native converter: #{inspect(reason)}
-        Input format: #{inspect(input_format)}
+        Input format: #{inspect(in_format)}
         Output format: #{inspect(out_format)}
         """
     end
@@ -266,7 +296,7 @@ defmodule Membrane.FFmpeg.SWResample.Converter do
   end
 
   defp calculate_output_duration(converted, state) do
-    byte_size(converted) / RawAudio.frame_size(state.output_stream_format) *
+    byte_size(converted) / RawAudio.frame_size(state.resolved_output_stream_format) *
       (RawAudio.frame_size(state.input_stream_format) * state.input_stream_format.sample_rate)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Membrane.FFmpeg.SWResample.Mixfile do
   use Mix.Project
 
   @github_url "https://github.com/membraneframework/membrane_ffmpeg_swresample_plugin"
-  @version "0.20.6"
+  @version "0.21.0"
 
   def project do
     [

--- a/test/membrane_ffmpeg_swresample_plugin/converter_test.exs
+++ b/test/membrane_ffmpeg_swresample_plugin/converter_test.exs
@@ -24,7 +24,8 @@ defmodule Membrane.FFmpeg.SWResample.ConverterTest do
       state: %{
         input_stream_format: nil,
         input_stream_format_provided?: false,
-        options_output_stream_format: Map.from_struct(@u8_format),
+        options_output_stream_format:
+          Map.from_struct(@u8_format) |> then(&struct!(Converter.OutputFormat, &1)),
         resolved_output_stream_format: @u8_format,
         frames_per_buffer: 2048,
         native: nil,

--- a/test/membrane_ffmpeg_swresample_plugin/converter_test.exs
+++ b/test/membrane_ffmpeg_swresample_plugin/converter_test.exs
@@ -24,7 +24,8 @@ defmodule Membrane.FFmpeg.SWResample.ConverterTest do
       state: %{
         input_stream_format: nil,
         input_stream_format_provided?: false,
-        output_stream_format: @u8_format,
+        options_output_stream_format: Map.from_struct(@u8_format),
+        resolved_output_stream_format: @u8_format,
         frames_per_buffer: 2048,
         native: nil,
         queue: <<>>,
@@ -41,7 +42,7 @@ defmodule Membrane.FFmpeg.SWResample.ConverterTest do
 
     assert {actions, new_state} = @module.handle_stream_format(:input, @s16le_format, nil, state)
 
-    assert actions == [stream_format: {:output, state.output_stream_format}]
+    assert actions == [stream_format: {:output, state.resolved_output_stream_format}]
 
     assert %{native: :mock_handle} = new_state
 
@@ -61,56 +62,6 @@ defmodule Membrane.FFmpeg.SWResample.ConverterTest do
   end
 
   setup_all :initial_state
-
-  describe "handle_setup/2" do
-    test "should do nothing if input stream format is not set", %{state: state} do
-      assert @module.handle_setup(nil, state) == {[], state}
-      refute_called!(@native, :create)
-    end
-
-    test "create native converter if stream format is set", %{state: initial_state} do
-      state = %{
-        initial_state
-        | input_stream_format: @s16le_format,
-          input_stream_format_provided?: true
-      }
-
-      Mockery.History.enable_history()
-      mock(@native, [create: 6], {:ok, :mock_handle})
-
-      assert {[], new_state} = @module.handle_setup(:stopped, state)
-
-      assert %{native: :mock_handle} = new_state
-
-      input_fmt = @s16le_format.sample_format |> RawAudio.SampleFormat.serialize()
-      input_rate = @s16le_format.sample_rate
-      input_channel = @s16le_format.channels
-      out_fmt = @u8_format.sample_format |> RawAudio.SampleFormat.serialize()
-      out_rate = @u8_format.sample_rate
-      out_channel = @u8_format.channels
-
-      assert_called!(
-        @native,
-        :create,
-        args: [^input_fmt, ^input_rate, ^input_channel, ^out_fmt, ^out_rate, ^out_channel],
-        times: 1
-      )
-    end
-
-    test "if native cannot be created returns an error with reason and untouched state", %{
-      state: initial_state
-    } do
-      state = %{
-        initial_state
-        | input_stream_format: @s16le_format,
-          input_stream_format_provided?: true
-      }
-
-      mock(@native, [create: 6], {:error, :reason})
-
-      assert_raise RuntimeError, fn -> @module.handle_setup(nil, state) end
-    end
-  end
 
   describe "handle_stream_format/4" do
     test "given new stream format when input_stream_format were not set should create native resource and store it in state",

--- a/test/membrane_ffmpeg_swresample_plugin/pipeline_test.exs
+++ b/test/membrane_ffmpeg_swresample_plugin/pipeline_test.exs
@@ -10,7 +10,13 @@ defmodule Membrane.FFmpeg.SWResample.PipelineTest do
   @tag :tmp_dir
   test "surrounded by testing source and sink", %{tmp_dir: tmp_dir} do
     input_stream_format = %RawAudio{sample_format: :u8, sample_rate: 8_000, channels: 1}
-    output_stream_format = %RawAudio{sample_format: :s16le, sample_rate: 16_000, channels: 2}
+
+    output_stream_format = %Converter.OutputFormat{
+      sample_format: :s16le,
+      sample_rate: 16_000,
+      channels: 2
+    }
+
     frames = 8_000
 
     input_time = RawAudio.frames_to_time(frames, input_stream_format)
@@ -34,7 +40,12 @@ defmodule Membrane.FFmpeg.SWResample.PipelineTest do
     Testing.Pipeline.terminate(pipeline)
 
     assert result = File.read!(output_path)
-    assert byte_size(result) == RawAudio.time_to_bytes(input_time, output_stream_format)
+
+    assert byte_size(result) ==
+             RawAudio.time_to_bytes(
+               input_time,
+               struct!(RawAudio, Map.from_struct(output_stream_format))
+             )
   end
 
   @tag :tmp_dir
@@ -42,7 +53,12 @@ defmodule Membrane.FFmpeg.SWResample.PipelineTest do
     tmp_dir: tmp_dir
   } do
     input_stream_format = %RawAudio{sample_format: :u8, sample_rate: 8_000, channels: 1}
-    output_stream_format = %{sample_format: :s16le, sample_rate: :keep, channels: :keep}
+
+    output_stream_format = %Converter.OutputFormat{
+      sample_format: :s16le,
+      sample_rate: :keep,
+      channels: :keep
+    }
 
     resolved_output_stream_format = %RawAudio{
       sample_format: :s16le,

--- a/test/membrane_ffmpeg_swresample_plugin/pipeline_test.exs
+++ b/test/membrane_ffmpeg_swresample_plugin/pipeline_test.exs
@@ -36,4 +36,43 @@ defmodule Membrane.FFmpeg.SWResample.PipelineTest do
     assert result = File.read!(output_path)
     assert byte_size(result) == RawAudio.time_to_bytes(input_time, output_stream_format)
   end
+
+  @tag :tmp_dir
+  test "keeps input stream format parameters for output_stream_format fields set to :keep", %{
+    tmp_dir: tmp_dir
+  } do
+    input_stream_format = %RawAudio{sample_format: :u8, sample_rate: 8_000, channels: 1}
+    output_stream_format = %{sample_format: :s16le, sample_rate: :keep, channels: :keep}
+
+    resolved_output_stream_format = %RawAudio{
+      sample_format: :s16le,
+      sample_rate: 8_000,
+      channels: 1
+    }
+
+    frames = 8_000
+
+    input_time = RawAudio.frames_to_time(frames, input_stream_format)
+    fixture_path = Path.expand(Path.join(__DIR__, "/../fixtures/input_u8_mono_8khz.raw"))
+
+    output_path = Path.expand(Path.join(tmp_dir, "output_s16le_mono_8khz.raw"))
+
+    spec = [
+      child(:source, %Membrane.File.Source{location: fixture_path})
+      |> child(:resampler, %Converter{
+        input_stream_format: input_stream_format,
+        output_stream_format: output_stream_format
+      })
+      |> child(:sink, %Membrane.File.Sink{location: output_path})
+    ]
+
+    pipeline = Testing.Pipeline.start_link_supervised!(spec: spec)
+
+    assert_pipeline_setup(pipeline)
+    assert_end_of_stream(pipeline, :sink)
+    Testing.Pipeline.terminate(pipeline)
+
+    assert result = File.read!(output_path)
+    assert byte_size(result) == RawAudio.time_to_bytes(input_time, resolved_output_stream_format)
+  end
 end

--- a/test/membrane_ffmpeg_swresample_plugin/pts_forward_test.exs
+++ b/test/membrane_ffmpeg_swresample_plugin/pts_forward_test.exs
@@ -15,7 +15,11 @@ defmodule Membrane.FFmpeg.SWResample.PtsForwardTest do
       |> child(:decoder_mp3, MP3.MAD.Decoder)
       |> child(:converter, %Converter{
         input_stream_format: %RawAudio{channels: 2, sample_format: :s24le, sample_rate: 48_000},
-        output_stream_format: %RawAudio{channels: 1, sample_format: :s16le, sample_rate: 44_100}
+        output_stream_format: %Converter.OutputFormat{
+          channels: 1,
+          sample_format: :s16le,
+          sample_rate: 44_100
+        }
       })
       |> child(:sink, Membrane.Testing.Sink)
 
@@ -27,7 +31,13 @@ defmodule Membrane.FFmpeg.SWResample.PtsForwardTest do
 
   test "pts forward test" do
     input_stream_format = %RawAudio{sample_format: :s16le, sample_rate: 16_000, channels: 2}
-    output_stream_format = %RawAudio{sample_format: :s32le, sample_rate: 32_000, channels: 2}
+
+    output_stream_format = %Converter.OutputFormat{
+      sample_format: :s32le,
+      sample_rate: 32_000,
+      channels: 2
+    }
+
     # 32 frames * 2048 bytes
     path = "test/fixtures/input_s16le_stereo_16khz.raw"
 


### PR DESCRIPTION
- Output stream format is now defined by a map instead of RawAudio struct. The only difference between these two is that the map allows for `:keep` value in all it's fields, which means that the actual value should be copied from input.
- Removed creating the native from `handle_setup/2` callback, since it's always created in non-raising `handle_stream_format/4` clauses.

A coding agent was used in the following ways:
- adding the test, its output wasn't corrected.
- adding `resolved_output_stream_format` in `converter.ex` where necessary, its output was heavily revised and corrected.